### PR TITLE
Adjust index.html for readability and accuracy

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,8 +17,7 @@
 
       <ul>
         <li><b>Time</b>: 7:00 pm on the first Thursday of each month</li>
-        <li><b>Location</b>: Offices of Secure One,
-	  <a href="http://goo.gl/maps/VYaD7">1518 1st Ave S, Seattle</a></li>
+        <li><b>Location</b>: No permanent address (any volunteers / companies in Seattle welcome to host!)</li>
         <li><a href="http://groups.google.com/group/seajure">Mailing
             list</a></li>
 	<li><a href="http://www.meetup.com/Seajure/">Meetup.com Web Site</a></li>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,19 @@
 
     <h4>Members</h4>
     <ul class="members">
-      <li><a href="http://technomancy.us">Phil Hagelberg</a></li><li><a href="http://threebrothers.org/brendan/">Brendan Ribera</a></li><li><a href="">Eric Hanchrow</a></li><li><a href="">Kevin Downey</a></li><li><a href="http://chewbranca.com">Russell Branca</a></li><li><a href="">Chris Bilson</a></li><li><a href="http://sgd.homelinux.net">Stan Dyck</a></li><li><a href="http://www.n10k.com">Nick Dimiduk</a></li><li><a href="http://justinlilly.com">Justin Lilly</a></li><li><a href="http://bitmechanic.com">James Cooper</a></li><li><a href="">Mark Engelberg</a></li><li><a href="http://copperthoughts.com">Isaac Hodes</a></li><li><a href="http://automatedlabs.com">Jeffrey Hulten</a></li>
+      <li><a href="http://technomancy.us">Phil Hagelberg</a></li>
+      <li><a href="http://threebrothers.org/brendan/">Brendan Ribera</a></li>
+      <li><a href="">Eric Hanchrow</a></li>
+      <li><a href="">Kevin Downey</a></li>
+      <li><a href="http://chewbranca.com">Russell Branca</a></li>
+      <li><a href="">Chris Bilson</a></li>
+      <li><a href="http://sgd.homelinux.net">Stan Dyck</a></li>
+      <li><a href="http://www.n10k.com">Nick Dimiduk</a></li>
+      <li><a href="http://justinlilly.com">Justin Lilly</a></li>
+      <li><a href="http://bitmechanic.com">James Cooper</a></li>
+      <li><a href="">Mark Engelberg</a></li>
+      <li><a href="http://copperthoughts.com">Isaac Hodes</a></li>
+      <li><a href="http://automatedlabs.com">Jeffrey Hulten</a></li>
     </ul>
 
     <p>See our <a href="https://github.com/Seajure">GitHub
@@ -52,13 +64,11 @@
 
     <hr />
 
-    <p id="join">If you want your name and projects to show up on this
+    <p id="join">If you want your name to show up on this
       page, get added to <a href="http://github.com/Seajure">the
-      Seajure organization on Github</a> and add your name and
-      projects to <a href="http://github.com/Seajure/seajure">this
-      site's repository</a>. Your name goes
-      in <code>resources/members.clj</code> and your projects
-      in <code>resources/projects.clj</code>.</p>
+      Seajure organization on Github</a> and add your name
+      to <a href="http://github.com/Seajure/seajure.github.com">
+      this site's repository</a>.</p>
   </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
       <li><a href="">Mark Engelberg</a></li>
       <li><a href="http://copperthoughts.com">Isaac Hodes</a></li>
       <li><a href="http://automatedlabs.com">Jeffrey Hulten</a></li>
+      <li><a href="http://github.com/aengelberg">Alex Engelberg</a></li>
     </ul>
 
     <p>See our <a href="https://github.com/Seajure">GitHub


### PR DESCRIPTION
We don't seem to be using the `Seajure / seajure` project Phil made a long time ago to generate the website resources, so I figured the front page should be pointing to this repo instead, since that's what people have been editing.

Also line-separated list of names so people can add themselves to the list.